### PR TITLE
Builds 404 page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ branches:
   only:
     - master
 
+git:
+  depth: 5
+
 install:
   - npm install
 
@@ -15,6 +18,9 @@ script:
 cache:
   directories:
     - "node_modules"
+
+before_deploy:
+  - cp docs/index.html docs/404.html
 
 deploy:
   provider: pages


### PR DESCRIPTION
This should allow gh-pages to serve the same file on every html request.

Also shortened git clone depth.